### PR TITLE
feat(groups/{c,d,f,s}*): vim syntax support

### DIFF
--- a/apparmor.d/groups/children/child-dpkg
+++ b/apparmor.d/groups/children/child-dpkg
@@ -50,3 +50,5 @@ profile child-dpkg {
 
   include if exists <local/child-dpkg>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/children/child-dpkg-divert
+++ b/apparmor.d/groups/children/child-dpkg-divert
@@ -31,3 +31,5 @@ profile child-dpkg-divert {
 
   include if exists <local/child-dpkg-divert>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/children/child-modprobe-nvidia
+++ b/apparmor.d/groups/children/child-modprobe-nvidia
@@ -79,3 +79,5 @@ profile child-modprobe-nvidia flags=(attach_disconnected) {
 
   include if exists <local/child-modprobe-nvidia>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/children/child-open
+++ b/apparmor.d/groups/children/child-open
@@ -27,3 +27,5 @@ profile child-open {
   include if exists <usr/child-open.d>
   include if exists <local/child-open>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/children/child-open-browsers
+++ b/apparmor.d/groups/children/child-open-browsers
@@ -24,3 +24,5 @@ profile child-open-browsers {
   include if exists <usr/child-open-browsers.d>
   include if exists <local/child-open-browsers>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/children/child-open-help
+++ b/apparmor.d/groups/children/child-open-help
@@ -16,3 +16,5 @@ profile child-open-help {
   include if exists <usr/child-open-help.d>
   include if exists <local/child-open-help>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/children/child-open-strict
+++ b/apparmor.d/groups/children/child-open-strict
@@ -21,3 +21,5 @@ profile child-open-strict {
   include if exists <usr/child-open-strict.d>
   include if exists <local/child-open-strict>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/children/child-pager
+++ b/apparmor.d/groups/children/child-pager
@@ -37,3 +37,5 @@ profile child-pager {
 
   include if exists <local/child-pager>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/children/child-systemctl
+++ b/apparmor.d/groups/children/child-systemctl
@@ -48,3 +48,5 @@ profile child-systemctl flags=(attach_disconnected) {
 
   include if exists <local/child-systemctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/children/user_confined
+++ b/apparmor.d/groups/children/user_confined
@@ -27,3 +27,5 @@ profile user_confined flags=(complain) {
 
   include if exists <local/user_confined>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/children/user_default
+++ b/apparmor.d/groups/children/user_default
@@ -28,3 +28,5 @@ profile user_default flags=(complain) {
 
   include if exists <local/user_default>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/children/user_unconfined
+++ b/apparmor.d/groups/children/user_unconfined
@@ -22,3 +22,5 @@ profile user_unconfined flags=(attach_disconnected,mediate_deleted) {
 
   include if exists <local/user_unconfined>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron
+++ b/apparmor.d/groups/cron/cron
@@ -78,3 +78,5 @@ profile cron @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/cron>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-anacron
+++ b/apparmor.d/groups/cron/cron-anacron
@@ -22,3 +22,5 @@ profile cron-anacron @{exec_path} {
 
   include if exists <local/cron-anacron>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-apport
+++ b/apparmor.d/groups/cron/cron-apport
@@ -22,3 +22,5 @@ profile cron-apport @{exec_path} {
 
   include if exists <local/cron-apport>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-apt
+++ b/apparmor.d/groups/cron/cron-apt
@@ -88,3 +88,5 @@ profile cron-apt @{exec_path} {
 
   include if exists <local/cron-apt>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-apt-compat
+++ b/apparmor.d/groups/cron/cron-apt-compat
@@ -27,3 +27,5 @@ profile cron-apt-compat @{exec_path} {
 
   include if exists <local/cron-apt-compat>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-apt-listbugs
+++ b/apparmor.d/groups/cron/cron-apt-listbugs
@@ -37,3 +37,5 @@ profile cron-apt-listbugs @{exec_path} {
 
   include if exists <local/cron-apt-listbugs>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-apt-show-versions
+++ b/apparmor.d/groups/cron/cron-apt-show-versions
@@ -21,3 +21,5 @@ profile cron-apt-show-versions @{exec_path} {
 
   include if exists <local/cron-apt-show-versions>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-apt-xapian-index
+++ b/apparmor.d/groups/cron/cron-apt-xapian-index
@@ -29,3 +29,5 @@ profile cron-apt-xapian-index @{exec_path} {
 
   include if exists <local/cron-apt-xapian-index>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-aptitude
+++ b/apparmor.d/groups/cron/cron-aptitude
@@ -34,3 +34,5 @@ profile cron-aptitude @{exec_path} {
 
   include if exists <local/cron-aptitude>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-cracklib
+++ b/apparmor.d/groups/cron/cron-cracklib
@@ -21,3 +21,5 @@ profile cron-cracklib @{exec_path} {
 
   include if exists <local/cron-cracklib>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-debsums
+++ b/apparmor.d/groups/cron/cron-debsums
@@ -47,3 +47,5 @@ profile cron-debsums @{exec_path} {
 
   include if exists <local/cron-debsums>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-debtags
+++ b/apparmor.d/groups/cron/cron-debtags
@@ -18,3 +18,5 @@ profile cron-debtags @{exec_path} {
 
   include if exists <local/cron-debtags>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-dlocate
+++ b/apparmor.d/groups/cron/cron-dlocate
@@ -18,3 +18,5 @@ profile cron-dlocate @{exec_path} {
 
   include if exists <local/cron-dlocate>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-etckeeper
+++ b/apparmor.d/groups/cron/cron-etckeeper
@@ -25,3 +25,5 @@ profile cron-etckeeper @{exec_path} {
 
   include if exists <local/cron-etckeeper>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-exim4-base
+++ b/apparmor.d/groups/cron/cron-exim4-base
@@ -55,3 +55,5 @@ profile cron-exim4-base @{exec_path} {
 
   include if exists <local/cron-exim4-base>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-ipset-autoban-save
+++ b/apparmor.d/groups/cron/cron-ipset-autoban-save
@@ -21,3 +21,5 @@ profile cron-ipset-autoban-save @{exec_path} {
 
   include if exists <local/cron-ipset-autoban-save>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-logrotate
+++ b/apparmor.d/groups/cron/cron-logrotate
@@ -23,3 +23,5 @@ profile cron-logrotate @{exec_path} {
 
   include if exists <local/cron-logrotate>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-man-db
+++ b/apparmor.d/groups/cron/cron-man-db
@@ -36,3 +36,5 @@ profile cron-man-db @{exec_path} {
 
   include if exists <local/cron-man-db>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-mlocate
+++ b/apparmor.d/groups/cron/cron-mlocate
@@ -29,3 +29,5 @@ profile cron-mlocate @{exec_path} {
 
   include if exists <local/cron-mlocate>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-ntp
+++ b/apparmor.d/groups/cron/cron-ntp
@@ -19,3 +19,5 @@ profile cron-ntp @{exec_path} {
 
   include if exists <local/cron-ntp>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-plocate
+++ b/apparmor.d/groups/cron/cron-plocate
@@ -29,3 +29,5 @@ profile cron-plocate @{exec_path} {
 
   include if exists <local/cron-plocate>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-popularity-contest
+++ b/apparmor.d/groups/cron/cron-popularity-contest
@@ -157,3 +157,5 @@ profile cron-popularity-contest @{exec_path} {
 
   include if exists <local/cron-popularity-contest>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/cron-sysstat
+++ b/apparmor.d/groups/cron/cron-sysstat
@@ -20,3 +20,5 @@ profile cron-sysstat @{exec_path} {
 
   include if exists <local/cron-sysstat>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/cron/crontab
+++ b/apparmor.d/groups/cron/crontab
@@ -49,3 +49,5 @@ profile crontab @{exec_path} {
 
   include if exists <local/crontab>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/display-manager/lightdm
+++ b/apparmor.d/groups/display-manager/lightdm
@@ -86,3 +86,5 @@ profile lightdm @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/lightdm>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/display-manager/lightdm-gtk-greeter
+++ b/apparmor.d/groups/display-manager/lightdm-gtk-greeter
@@ -53,3 +53,5 @@ profile lightdm-gtk-greeter @{exec_path} {
 
   include if exists <local/lightdm-gtk-greeter>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/display-manager/lightdm-xsession
+++ b/apparmor.d/groups/display-manager/lightdm-xsession
@@ -50,3 +50,5 @@ profile lightdm-xsession @{exec_path} {
 
   include if exists <local/lightdm-xsession>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/display-manager/x11-xsession
+++ b/apparmor.d/groups/display-manager/x11-xsession
@@ -146,3 +146,5 @@ profile x11-xsession @{exec_path} {
 
   include if exists <local/x11-xsession>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/display-manager/xdm-xsession
+++ b/apparmor.d/groups/display-manager/xdm-xsession
@@ -106,3 +106,5 @@ profile xdm-xsession @{exec_path} {
 
   include if exists <local/xdm-xsession>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/accounts-daemon
+++ b/apparmor.d/groups/freedesktop/accounts-daemon
@@ -79,3 +79,5 @@ profile accounts-daemon @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/accounts-daemon>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/colord
+++ b/apparmor.d/groups/freedesktop/colord
@@ -77,3 +77,5 @@ profile colord @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/colord>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/colord-session
+++ b/apparmor.d/groups/freedesktop/colord-session
@@ -18,3 +18,5 @@ profile colord-session @{exec_path} {
 
   include if exists <local/colord-session>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/cpupower
+++ b/apparmor.d/groups/freedesktop/cpupower
@@ -56,3 +56,5 @@ profile cpupower @{exec_path} {
 
   include if exists <local/cpupower>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/dconf
+++ b/apparmor.d/groups/freedesktop/dconf
@@ -29,3 +29,5 @@ profile dconf @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/dconf>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/dconf-editor
+++ b/apparmor.d/groups/freedesktop/dconf-editor
@@ -26,3 +26,5 @@ profile dconf-editor @{exec_path} {
 
   include if exists <local/dconf-editor>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/dconf-service
+++ b/apparmor.d/groups/freedesktop/dconf-service
@@ -42,3 +42,5 @@ profile dconf-service @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/dconf-service>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/desktop-file-install
+++ b/apparmor.d/groups/freedesktop/desktop-file-install
@@ -14,3 +14,5 @@ profile desktop-file-install @{exec_path} {
 
   include if exists <local/desktop-file-install>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/fc-cache
+++ b/apparmor.d/groups/freedesktop/fc-cache
@@ -32,3 +32,5 @@ profile fc-cache @{exec_path} {
 
   include if exists <local/fc-cache>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/fc-list
+++ b/apparmor.d/groups/freedesktop/fc-list
@@ -19,3 +19,5 @@ profile fc-list @{exec_path} {
 
   include if exists <local/fc-list>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/geoclue
+++ b/apparmor.d/groups/freedesktop/geoclue
@@ -48,3 +48,5 @@ profile geoclue @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/geoclue>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/iio-sensor-proxy
+++ b/apparmor.d/groups/freedesktop/iio-sensor-proxy
@@ -37,3 +37,5 @@ profile iio-sensor-proxy @{exec_path} {
 
   include if exists <local/iio-sensor-proxy>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/pipewire
+++ b/apparmor.d/groups/freedesktop/pipewire
@@ -74,3 +74,5 @@ profile pipewire @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/pipewire>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/pipewire-media-session
+++ b/apparmor.d/groups/freedesktop/pipewire-media-session
@@ -68,3 +68,5 @@ profile pipewire-media-session @{exec_path} {
 
   include if exists <local/pipewire-media-session>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/pipewire-pulse
+++ b/apparmor.d/groups/freedesktop/pipewire-pulse
@@ -41,3 +41,5 @@ profile pipewire-pulse @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/pipewire-pulse>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/plymouth
+++ b/apparmor.d/groups/freedesktop/plymouth
@@ -21,3 +21,5 @@ profile plymouth @{exec_path} {
 
   include if exists <local/plymouth>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/plymouth-set-default-theme
+++ b/apparmor.d/groups/freedesktop/plymouth-set-default-theme
@@ -26,3 +26,5 @@ profile plymouth-set-default-theme @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/plymouth-set-default-theme>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/plymouthd
+++ b/apparmor.d/groups/freedesktop/plymouthd
@@ -71,3 +71,5 @@ profile plymouthd @{exec_path} {
 
   include if exists <local/plymouthd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/polkit-agent-helper
+++ b/apparmor.d/groups/freedesktop/polkit-agent-helper
@@ -54,3 +54,5 @@ profile polkit-agent-helper @{exec_path} {
 
   include if exists <local/polkit-agent-helper>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/polkit-gnome-authentication-agent
+++ b/apparmor.d/groups/freedesktop/polkit-gnome-authentication-agent
@@ -21,3 +21,5 @@ profile polkit-gnome-authentication-agent @{exec_path} {
 
   include if exists <local/polkit-gnome-authentication-agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/polkit-kde-authentication-agent
+++ b/apparmor.d/groups/freedesktop/polkit-kde-authentication-agent
@@ -56,3 +56,5 @@ profile polkit-kde-authentication-agent @{exec_path} flags=(attach_disconnected,
 
   include if exists <local/polkit-kde-authentication-agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/polkit-mate-authentication-agent
+++ b/apparmor.d/groups/freedesktop/polkit-mate-authentication-agent
@@ -41,3 +41,5 @@ profile polkit-mate-authentication-agent @{exec_path} {
 
   include if exists <local/polkit-mate-authentication-agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/polkitd
+++ b/apparmor.d/groups/freedesktop/polkitd
@@ -72,3 +72,5 @@ profile polkitd @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/polkitd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/pulseaudio
+++ b/apparmor.d/groups/freedesktop/pulseaudio
@@ -118,3 +118,5 @@ profile pulseaudio @{exec_path} {
 
   include if exists <local/pulseaudio>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/update-desktop-database
+++ b/apparmor.d/groups/freedesktop/update-desktop-database
@@ -40,3 +40,5 @@ profile update-desktop-database @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/update-desktop-database>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/update-mime-database
+++ b/apparmor.d/groups/freedesktop/update-mime-database
@@ -32,3 +32,5 @@ profile update-mime-database @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/update-mime-database>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/upower
+++ b/apparmor.d/groups/freedesktop/upower
@@ -18,3 +18,5 @@ profile upower @{exec_path} {
 
   include if exists <local/upower>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/upowerd
+++ b/apparmor.d/groups/freedesktop/upowerd
@@ -60,3 +60,5 @@ profile upowerd @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/upowerd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-dbus-proxy
+++ b/apparmor.d/groups/freedesktop/xdg-dbus-proxy
@@ -42,3 +42,5 @@ profile xdg-dbus-proxy @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/xdg-dbus-proxy>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-desktop-icon
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-icon
@@ -14,3 +14,5 @@ profile xdg-desktop-icon @{exec_path} {
 
   include if exists <local/xdg-desktop-icon>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-desktop-menu
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-menu
@@ -44,3 +44,5 @@ profile xdg-desktop-menu @{exec_path} flags=(complain) {
 
   include if exists <local/xdg-desktop-menu>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-desktop-portal
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-portal
@@ -100,3 +100,5 @@ profile xdg-desktop-portal @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/xdg-desktop-portal>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-desktop-portal-gnome
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-portal-gnome
@@ -88,3 +88,5 @@ profile xdg-desktop-portal-gnome @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/xdg-desktop-portal-gnome>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-desktop-portal-gtk
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-portal-gtk
@@ -65,3 +65,5 @@ profile xdg-desktop-portal-gtk @{exec_path} {
 
   include if exists <local/xdg-desktop-portal-gtk>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-desktop-portal-kde
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-portal-kde
@@ -42,3 +42,5 @@ profile xdg-desktop-portal-kde @{exec_path} {
 
   include if exists <local/xdg-desktop-portal-kde>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-desktop-portal-rewrite-launchers
+++ b/apparmor.d/groups/freedesktop/xdg-desktop-portal-rewrite-launchers
@@ -16,3 +16,5 @@ profile xdg-desktop-portal-rewrite-launchers @{exec_path} {
 
   include if exists <local/xdg-desktop-portal-rewrite-launchers>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-document-portal
+++ b/apparmor.d/groups/freedesktop/xdg-document-portal
@@ -88,3 +88,5 @@ profile xdg-document-portal @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/xdg-document-portal>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-email
+++ b/apparmor.d/groups/freedesktop/xdg-email
@@ -32,3 +32,5 @@ profile xdg-email @{exec_path} flags=(complain) {
 
   include if exists <local/xdg-email>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-icon-resource
+++ b/apparmor.d/groups/freedesktop/xdg-icon-resource
@@ -43,3 +43,5 @@ profile xdg-icon-resource @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/xdg-icon-resource>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-mime
+++ b/apparmor.d/groups/freedesktop/xdg-mime
@@ -77,3 +77,5 @@ profile xdg-mime @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/xdg-mime>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-open
+++ b/apparmor.d/groups/freedesktop/xdg-open
@@ -59,3 +59,5 @@ profile xdg-open @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/xdg-open>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-permission-store
+++ b/apparmor.d/groups/freedesktop/xdg-permission-store
@@ -49,3 +49,5 @@ profile xdg-permission-store @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/xdg-permission-store>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-screensaver
+++ b/apparmor.d/groups/freedesktop/xdg-screensaver
@@ -42,3 +42,5 @@ profile xdg-screensaver @{exec_path} {
 
   include if exists <local/xdg-screensaver>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-settings
+++ b/apparmor.d/groups/freedesktop/xdg-settings
@@ -66,3 +66,5 @@ profile xdg-settings @{exec_path} {
 
   include if exists <local/xdg-settings>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-user-dir
+++ b/apparmor.d/groups/freedesktop/xdg-user-dir
@@ -26,3 +26,5 @@ profile xdg-user-dir @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/xdg-user-dir>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-user-dirs-gtk-update
+++ b/apparmor.d/groups/freedesktop/xdg-user-dirs-gtk-update
@@ -19,3 +19,5 @@ profile xdg-user-dirs-gtk-update @{exec_path} {
 
   include if exists <local/xdg-user-dirs-gtk-update>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xdg-user-dirs-update
+++ b/apparmor.d/groups/freedesktop/xdg-user-dirs-update
@@ -43,3 +43,5 @@ profile xdg-user-dirs-update @{exec_path} {
 
   include if exists <local/xdg-user-dirs-update>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xhost
+++ b/apparmor.d/groups/freedesktop/xhost
@@ -22,3 +22,5 @@ profile xhost @{exec_path} {
 
   include if exists <local/xhost>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xkbcomp
+++ b/apparmor.d/groups/freedesktop/xkbcomp
@@ -43,3 +43,5 @@ profile xkbcomp @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/xkbcomp>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xorg
+++ b/apparmor.d/groups/freedesktop/xorg
@@ -134,3 +134,5 @@ profile xorg @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/xorg>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xprop
+++ b/apparmor.d/groups/freedesktop/xprop
@@ -17,3 +17,5 @@ profile xprop @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/xprop>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xrandr
+++ b/apparmor.d/groups/freedesktop/xrandr
@@ -18,3 +18,5 @@ profile xrandr @{exec_path} {
 
   include if exists <local/xrandr>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xrdb
+++ b/apparmor.d/groups/freedesktop/xrdb
@@ -57,3 +57,5 @@ profile xrdb @{exec_path} {
   include if exists <local/xrdb>
 }
 
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xset
+++ b/apparmor.d/groups/freedesktop/xset
@@ -28,3 +28,5 @@ profile xset @{exec_path} {
 
   include if exists <local/xset>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xsetroot
+++ b/apparmor.d/groups/freedesktop/xsetroot
@@ -33,3 +33,5 @@ profile xsetroot @{exec_path} {
 
   include if exists <local/xsetroot>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/freedesktop/xwayland
+++ b/apparmor.d/groups/freedesktop/xwayland
@@ -38,3 +38,5 @@ profile xwayland @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/xwayland>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/ssh/sftp-server
+++ b/apparmor.d/groups/ssh/sftp-server
@@ -23,3 +23,5 @@ profile sftp-server @{exec_path} {
 
   include if exists <local/sftp-server>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/ssh/ssh
+++ b/apparmor.d/groups/ssh/ssh
@@ -51,3 +51,5 @@ profile ssh @{exec_path} {
 
   include if exists <local/ssh>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/ssh/ssh-agent
+++ b/apparmor.d/groups/ssh/ssh-agent
@@ -37,3 +37,5 @@ profile ssh-agent @{exec_path} {
 
   include if exists <local/ssh-agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/ssh/ssh-agent-launch
+++ b/apparmor.d/groups/ssh/ssh-agent-launch
@@ -41,3 +41,5 @@ profile ssh-agent-launch @{exec_path} {
 
   include if exists <local/ssh-agent-launch>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/ssh/ssh-keygen
+++ b/apparmor.d/groups/ssh/ssh-keygen
@@ -26,3 +26,5 @@ profile ssh-keygen @{exec_path} {
 
   include if exists <local/ssh-keygen>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/ssh/sshd
+++ b/apparmor.d/groups/ssh/sshd
@@ -123,3 +123,5 @@ profile sshd @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/sshd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/ssh/sshfs
+++ b/apparmor.d/groups/ssh/sshfs
@@ -49,3 +49,5 @@ profile sshfs @{exec_path} flags=(complain) {
 
   include if exists <local/sshfs>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/bootctl
+++ b/apparmor.d/groups/systemd/bootctl
@@ -78,3 +78,5 @@ profile bootctl @{exec_path} {
 
   include if exists <local/bootctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/busctl
+++ b/apparmor.d/groups/systemd/busctl
@@ -50,3 +50,5 @@ profile busctl @{exec_path} {
 
   include if exists <local/busctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/coredumpctl
+++ b/apparmor.d/groups/systemd/coredumpctl
@@ -74,3 +74,5 @@ profile coredumpctl @{exec_path} flags=(complain) {
 
   include if exists <local/coredumpctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/hostnamectl
+++ b/apparmor.d/groups/systemd/hostnamectl
@@ -24,3 +24,5 @@ profile hostnamectl @{exec_path} {
 
   include if exists <local/hostnamectl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/journalctl
+++ b/apparmor.d/groups/systemd/journalctl
@@ -59,3 +59,5 @@ profile journalctl @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-journalctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/localectl
+++ b/apparmor.d/groups/systemd/localectl
@@ -23,3 +23,5 @@ profile localectl @{exec_path} {
 
   include if exists <local/localectl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/loginctl
+++ b/apparmor.d/groups/systemd/loginctl
@@ -25,3 +25,5 @@ profile loginctl @{exec_path} {
 
   include if exists <local/loginctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/networkctl
+++ b/apparmor.d/groups/systemd/networkctl
@@ -67,3 +67,5 @@ profile networkctl @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/networkctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-ac-power
+++ b/apparmor.d/groups/systemd/systemd-ac-power
@@ -22,3 +22,5 @@ profile systemd-ac-power @{exec_path} {
 
   include if exists <local/systemd-ac-power>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-analyze
+++ b/apparmor.d/groups/systemd/systemd-analyze
@@ -69,3 +69,5 @@ profile systemd-analyze @{exec_path} {
 
   include if exists <local/systemd-analyze>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-ask-password
+++ b/apparmor.d/groups/systemd/systemd-ask-password
@@ -17,3 +17,5 @@ profile systemd-ask-password @{exec_path} {
 
   include if exists <local/systemd-ask-password>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-backlight
+++ b/apparmor.d/groups/systemd/systemd-backlight
@@ -44,3 +44,5 @@ profile systemd-backlight @{exec_path} {
 
   include if exists <local/systemd-backlight>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-binfmt
+++ b/apparmor.d/groups/systemd/systemd-binfmt
@@ -30,3 +30,5 @@ profile systemd-binfmt @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-binfmt>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-cat
+++ b/apparmor.d/groups/systemd/systemd-cat
@@ -19,3 +19,5 @@ profile systemd-cat @{exec_path} {
 
   include if exists <local/systemd-cat>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-cgls
+++ b/apparmor.d/groups/systemd/systemd-cgls
@@ -26,3 +26,5 @@ profile systemd-cgls @{exec_path} {
 
   include if exists <local/systemd-cgls>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-cgtop
+++ b/apparmor.d/groups/systemd/systemd-cgtop
@@ -24,3 +24,5 @@ profile systemd-cgtop @{exec_path} {
 
   include if exists <local/systemd-cgtop>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-coredump
+++ b/apparmor.d/groups/systemd/systemd-coredump
@@ -54,3 +54,5 @@ profile systemd-coredump @{exec_path} flags=(attach_disconnected,mediate_deleted
 
   include if exists <local/systemd-coredump>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-cryptsetup
+++ b/apparmor.d/groups/systemd/systemd-cryptsetup
@@ -37,3 +37,5 @@ profile systemd-cryptsetup @{exec_path} {
 
   include if exists <local/systemd-cryptsetup>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-delta
+++ b/apparmor.d/groups/systemd/systemd-delta
@@ -31,3 +31,5 @@ profile systemd-delta @{exec_path} {
 
   include if exists <local/systemd-delta>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-detect-virt
+++ b/apparmor.d/groups/systemd/systemd-detect-virt
@@ -32,3 +32,5 @@ profile systemd-detect-virt @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-detect-virt>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-dissect
+++ b/apparmor.d/groups/systemd/systemd-dissect
@@ -48,3 +48,5 @@ profile systemd-dissect @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-dissect>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-escape
+++ b/apparmor.d/groups/systemd/systemd-escape
@@ -15,3 +15,5 @@ profile systemd-escape @{exec_path} {
 
   include if exists <local/systemd-escape>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-fsck
+++ b/apparmor.d/groups/systemd/systemd-fsck
@@ -28,3 +28,5 @@ profile systemd-fsck @{exec_path} {
 
   include if exists <local/systemd-fsck>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-fsckd
+++ b/apparmor.d/groups/systemd/systemd-fsckd
@@ -22,3 +22,5 @@ profile systemd-fsckd @{exec_path} {
 
   include if exists <local/systemd-fsckd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-bless-boot
+++ b/apparmor.d/groups/systemd/systemd-generator-bless-boot
@@ -17,3 +17,5 @@ profile systemd-generator-bless-boot @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-generator-bless-boot>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-cloud-init
+++ b/apparmor.d/groups/systemd/systemd-generator-cloud-init
@@ -27,3 +27,5 @@ profile systemd-generator-cloud-init @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-generator-cloud-init>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-cryptsetup
+++ b/apparmor.d/groups/systemd/systemd-generator-cryptsetup
@@ -22,3 +22,5 @@ profile systemd-generator-cryptsetup @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-generator-cryptsetup>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-debug
+++ b/apparmor.d/groups/systemd/systemd-generator-debug
@@ -17,3 +17,5 @@ profile systemd-generator-debug @{exec_path} flags=(attach_disconnected)  {
 
   include if exists <local/systemd-generator-debug>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-ds-identify
+++ b/apparmor.d/groups/systemd/systemd-generator-ds-identify
@@ -40,3 +40,5 @@ profile systemd-generator-ds-identify @{exec_path} flags=(attach_disconnected) {
   include if exists <local/systemd-generator-ds-identify>
 }
 
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-environment-arch
+++ b/apparmor.d/groups/systemd/systemd-generator-environment-arch
@@ -18,3 +18,5 @@ profile systemd-generator-environment-arch @{exec_path} {
 
   include if exists <local/systemd-generator-environment-arch>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-environment-flatpak
+++ b/apparmor.d/groups/systemd/systemd-generator-environment-flatpak
@@ -22,3 +22,5 @@ profile systemd-generator-environment-flatpak @{exec_path} {
 
   include if exists <local/systemd-generator-environment-flatpak>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-fstab
+++ b/apparmor.d/groups/systemd/systemd-generator-fstab
@@ -24,3 +24,5 @@ profile systemd-generator-fstab @{exec_path} {
 
   include if exists <local/systemd-generator-fstab>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-getty
+++ b/apparmor.d/groups/systemd/systemd-generator-getty
@@ -25,3 +25,5 @@ profile systemd-generator-getty @{exec_path} flags=(attach_disconnected)  {
 
   include if exists <local/systemd-generator-getty>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-gpt-auto
+++ b/apparmor.d/groups/systemd/systemd-generator-gpt-auto
@@ -31,3 +31,5 @@ profile systemd-generator-gpt-auto @{exec_path} flags=(attach_disconnected)  {
 
   include if exists <local/systemd-generator-gpt-auto>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-hibernate-resume
+++ b/apparmor.d/groups/systemd/systemd-generator-hibernate-resume
@@ -17,3 +17,5 @@ profile systemd-generator-hibernate-resume @{exec_path} flags=(attach_disconnect
 
   include if exists <local/systemd-generator-hibernate-resume>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-integritysetup
+++ b/apparmor.d/groups/systemd/systemd-generator-integritysetup
@@ -17,3 +17,5 @@ profile systemd-generator-integritysetup @{exec_path} flags=(attach_disconnected
 
   include if exists <local/systemd-generator-integritysetup>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-ostree
+++ b/apparmor.d/groups/systemd/systemd-generator-ostree
@@ -16,3 +16,5 @@ profile systemd-generator-ostree @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-generator-ostree>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-run
+++ b/apparmor.d/groups/systemd/systemd-generator-run
@@ -23,3 +23,5 @@ profile systemd-generator-run @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-generator-run>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-system-update
+++ b/apparmor.d/groups/systemd/systemd-generator-system-update
@@ -17,3 +17,5 @@ profile systemd-generator-system-update @{exec_path} flags=(attach_disconnected)
 
   include if exists <local/systemd-generator-system-update>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-user-autostart
+++ b/apparmor.d/groups/systemd/systemd-generator-user-autostart
@@ -25,3 +25,5 @@ profile systemd-generator-user-autostart @{exec_path} {
 
   include if exists <local/systemd-generator-user-autostart>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-user-environment
+++ b/apparmor.d/groups/systemd/systemd-generator-user-environment
@@ -30,3 +30,5 @@ profile systemd-generator-user-environment @{exec_path} {
 
   include if exists <local/systemd-generator-user-environment>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-generator-veritysetup
+++ b/apparmor.d/groups/systemd/systemd-generator-veritysetup
@@ -19,3 +19,5 @@ profile systemd-generator-veritysetup @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-generator-veritysetup>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-homed
+++ b/apparmor.d/groups/systemd/systemd-homed
@@ -83,3 +83,5 @@ profile systemd-homed @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-homed>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-homework
+++ b/apparmor.d/groups/systemd/systemd-homework
@@ -18,3 +18,5 @@ profile systemd-homework @{exec_path} {
 
   include if exists <local/systemd-homework>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-hostnamed
+++ b/apparmor.d/groups/systemd/systemd-hostnamed
@@ -53,3 +53,5 @@ profile systemd-hostnamed @{exec_path}  flags=(attach_disconnected) {
 
   include if exists <local/systemd-hostnamed>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-hwdb
+++ b/apparmor.d/groups/systemd/systemd-hwdb
@@ -27,3 +27,5 @@ profile systemd-hwdb @{exec_path} flags=(attach_disconnected,mediate_deleted) {
 
   include if exists <local/systemd-hwdb>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-id128
+++ b/apparmor.d/groups/systemd/systemd-id128
@@ -19,3 +19,5 @@ profile systemd-id128 @{exec_path} {
 
   include if exists <local/systemd-id128>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-inhibit
+++ b/apparmor.d/groups/systemd/systemd-inhibit
@@ -22,3 +22,5 @@ profile systemd-inhibit @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-inhibit>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-journald
+++ b/apparmor.d/groups/systemd/systemd-journald
@@ -89,3 +89,5 @@ profile systemd-journald @{exec_path} {
 
   include if exists <local/systemd-journald>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-localed
+++ b/apparmor.d/groups/systemd/systemd-localed
@@ -38,3 +38,5 @@ profile systemd-localed @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-localed>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-logind
+++ b/apparmor.d/groups/systemd/systemd-logind
@@ -144,3 +144,5 @@ profile systemd-logind @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-logind>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-machine-id-setup
+++ b/apparmor.d/groups/systemd/systemd-machine-id-setup
@@ -37,3 +37,5 @@ profile systemd-machine-id-setup @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-machine-id-setup>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-machined
+++ b/apparmor.d/groups/systemd/systemd-machined
@@ -50,3 +50,5 @@ profile systemd-machined @{exec_path} {
 
   include if exists <local/systemd-machined>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-makefs
+++ b/apparmor.d/groups/systemd/systemd-makefs
@@ -22,3 +22,5 @@ profile systemd-makefs @{exec_path} {
 
   include if exists <local/systemd-makefs>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-modules-load
+++ b/apparmor.d/groups/systemd/systemd-modules-load
@@ -29,3 +29,5 @@ profile systemd-modules-load @{exec_path} {
 
   include if exists <local/systemd-modules-load>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-mount
+++ b/apparmor.d/groups/systemd/systemd-mount
@@ -24,3 +24,5 @@ profile systemd-mount @{exec_path} {
 
   include if exists <local/systemd-mount>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-network-generator
+++ b/apparmor.d/groups/systemd/systemd-network-generator
@@ -19,3 +19,5 @@ profile systemd-network-generator @{exec_path} {
 
   include if exists <local/systemd-network-generator>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-networkd
+++ b/apparmor.d/groups/systemd/systemd-networkd
@@ -75,3 +75,5 @@ profile systemd-networkd @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-networkd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-networkd-wait-online
+++ b/apparmor.d/groups/systemd/systemd-networkd-wait-online
@@ -22,3 +22,5 @@ profile systemd-networkd-wait-online @{exec_path} flags=(complain) {
 
   include if exists <local/systemd-networkd-wait-online>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-notify
+++ b/apparmor.d/groups/systemd/systemd-notify
@@ -17,3 +17,5 @@ profile systemd-notify @{exec_path} {
 
   include if exists <local/systemd-notify>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-oomd
+++ b/apparmor.d/groups/systemd/systemd-oomd
@@ -40,3 +40,5 @@ profile systemd-oomd @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-oomd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-path
+++ b/apparmor.d/groups/systemd/systemd-path
@@ -17,3 +17,5 @@ profile systemd-path @{exec_path} {
 
   include if exists <local/systemd-path>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-portabled
+++ b/apparmor.d/groups/systemd/systemd-portabled
@@ -37,3 +37,5 @@ profile systemd-portabled @{exec_path} {
 
   include if exists <local/systemd-portabled>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-random-seed
+++ b/apparmor.d/groups/systemd/systemd-random-seed
@@ -26,3 +26,5 @@ profile systemd-random-seed @{exec_path} {
 
   include if exists <local/systemd-random-seed>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-remount-fs
+++ b/apparmor.d/groups/systemd/systemd-remount-fs
@@ -37,3 +37,5 @@ profile systemd-remount-fs @{exec_path} {
 
   include if exists <local/systemd-remount-fs>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-resolve
+++ b/apparmor.d/groups/systemd/systemd-resolve
@@ -23,3 +23,5 @@ profile systemd-resolve @{exec_path} {
 
   include if exists <local/systemd-resolve>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-resolved
+++ b/apparmor.d/groups/systemd/systemd-resolved
@@ -53,3 +53,5 @@ profile systemd-resolved @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-timesyncd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-rfkill
+++ b/apparmor.d/groups/systemd/systemd-rfkill
@@ -30,3 +30,5 @@ profile systemd-rfkill @{exec_path} {
 
   include if exists <local/systemd-rfkill>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-shutdown
+++ b/apparmor.d/groups/systemd/systemd-shutdown
@@ -36,3 +36,5 @@ profile systemd-shutdown @{exec_path} {
 
   include if exists <local/systemd-shutdown>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-sleep
+++ b/apparmor.d/groups/systemd/systemd-sleep
@@ -34,3 +34,5 @@ profile systemd-sleep @{exec_path} {
 
   include if exists <local/systemd-sleep>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-sleep-grub2
+++ b/apparmor.d/groups/systemd/systemd-sleep-grub2
@@ -25,3 +25,5 @@ profile systemd-sleep-grub @{exec_path} {
 
   include if exists <local/systemd-sleep-grub>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-sleep-hdparm
+++ b/apparmor.d/groups/systemd/systemd-sleep-hdparm
@@ -14,3 +14,5 @@ profile systemd-sleep-hdparm @{exec_path} {
 
   include if exists <local/systemd-sleep-hdparm>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-sleep-nvidia
+++ b/apparmor.d/groups/systemd/systemd-sleep-nvidia
@@ -31,3 +31,5 @@ profile systemd-sleep-nvidia @{exec_path} {
 
   include if exists <local/systemd-sleep-nvidia>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-sleep-sysstat
+++ b/apparmor.d/groups/systemd/systemd-sleep-sysstat
@@ -14,3 +14,5 @@ profile systemd-sleep-sysstat @{exec_path} {
 
   include if exists <local/systemd-sleep-sysstat>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-sleep-tlp
+++ b/apparmor.d/groups/systemd/systemd-sleep-tlp
@@ -16,3 +16,5 @@ profile systemd-sleep-tlp @{exec_path} {
 
   include if exists <local/systemd-sleep-tlp>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-sleep-upgrades
+++ b/apparmor.d/groups/systemd/systemd-sleep-upgrades
@@ -14,3 +14,5 @@ profile systemd-sleep-upgrades @{exec_path} {
 
   include if exists <local/systemd-sleep-upgrades>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-socket-proxyd
+++ b/apparmor.d/groups/systemd/systemd-socket-proxyd
@@ -20,3 +20,5 @@ profile systemd-socket-proxyd @{exec_path} {
 
   include if exists <local/systemd-socket-proxyd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-sulogin-shell
+++ b/apparmor.d/groups/systemd/systemd-sulogin-shell
@@ -22,3 +22,5 @@ profile systemd-sulogin-shell @{exec_path} {
 
   include if exists <local/systemd-sulogin-shell>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-sysctl
+++ b/apparmor.d/groups/systemd/systemd-sysctl
@@ -31,3 +31,5 @@ profile systemd-sysctl @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-sysctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-sysusers
+++ b/apparmor.d/groups/systemd/systemd-sysusers
@@ -49,3 +49,5 @@ profile systemd-sysusers @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-sysusers>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-timedated
+++ b/apparmor.d/groups/systemd/systemd-timedated
@@ -41,3 +41,5 @@ profile systemd-timedated @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-timedated>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-timesyncd
+++ b/apparmor.d/groups/systemd/systemd-timesyncd
@@ -46,3 +46,5 @@ profile systemd-timesyncd @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-timesyncd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-tmpfiles
+++ b/apparmor.d/groups/systemd/systemd-tmpfiles
@@ -59,3 +59,5 @@ profile systemd-tmpfiles @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-tmpfiles>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-tty-ask-password-agent
+++ b/apparmor.d/groups/systemd/systemd-tty-ask-password-agent
@@ -35,3 +35,5 @@ profile systemd-tty-ask-password-agent @{exec_path} {
 
   include if exists <local/systemd-tty-ask-password-agent>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-udevd
+++ b/apparmor.d/groups/systemd/systemd-udevd
@@ -130,3 +130,5 @@ profile systemd-udevd @{exec_path} flags=(attach_disconnected,complain) {
 
   include if exists <local/systemd-udevd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-update-done
+++ b/apparmor.d/groups/systemd/systemd-update-done
@@ -30,3 +30,5 @@ profile systemd-update-done @{exec_path} {
 
   include if exists <local/systemd-update-done>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-update-utmp
+++ b/apparmor.d/groups/systemd/systemd-update-utmp
@@ -26,3 +26,5 @@ profile systemd-update-utmp @{exec_path} {
 
   include if exists <local/systemd-update-utmp>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-user-runtime-dir
+++ b/apparmor.d/groups/systemd/systemd-user-runtime-dir
@@ -33,3 +33,5 @@ profile systemd-user-runtime-dir @{exec_path} {
 
   include if exists <local/systemd-user-runtime-dir>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-user-sessions
+++ b/apparmor.d/groups/systemd/systemd-user-sessions
@@ -23,3 +23,5 @@ profile systemd-user-sessions @{exec_path} {
 
   include if exists <local/systemd-user-sessions>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-userdbd
+++ b/apparmor.d/groups/systemd/systemd-userdbd
@@ -37,3 +37,5 @@ profile systemd-userdbd @{exec_path} flags=(attach_disconnected,mediate_deleted)
 
   include if exists <local/systemd-userdbd>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-userwork
+++ b/apparmor.d/groups/systemd/systemd-userwork
@@ -23,3 +23,5 @@ profile systemd-userwork @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/systemd-userwork>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/systemd-vconsole-setup
+++ b/apparmor.d/groups/systemd/systemd-vconsole-setup
@@ -39,3 +39,5 @@ profile systemd-vconsole-setup @{exec_path} {
 
   include if exists <local/systemd-vconsole-setup>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/userdbctl
+++ b/apparmor.d/groups/systemd/userdbctl
@@ -27,3 +27,5 @@ profile userdbctl @{exec_path} {
 
   include if exists <local/userdbctl>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/zram-generator
+++ b/apparmor.d/groups/systemd/zram-generator
@@ -37,3 +37,5 @@ profile zram-generator @{exec_path} flags=(attach_disconnected) {
 
   include if exists <local/zram-generator>
 }
+
+# vim:syntax=apparmor

--- a/apparmor.d/groups/systemd/zramctl
+++ b/apparmor.d/groups/systemd/zramctl
@@ -21,3 +21,5 @@ profile zramctl @{exec_path} {
 
   include if exists <local/zramctl>
 }
+
+# vim:syntax=apparmor


### PR DESCRIPTION
Add vim modeline instructing the editor to use syntax plugin provided by apparmor. Continuation of #392 to keep the diff list relatively short.